### PR TITLE
Some minor improvements to command line arguments parsing

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,14 +77,10 @@ pub fn tool<T>(description: &'static str, usage: &'static str) -> OptionParser<B
 
 /// Gets the baseline default options that every tool needs.
 pub fn default() -> impl Parser<BaseOptions> {
-    let inputs = inputs();
-    let output = output();
-    let verbose = verbose();
-
     construct!(BaseOptions {
-        output,
-        verbose,
-        inputs,
+        output(),
+        verbose(),
+        inputs(),
     })
 }
 


### PR DESCRIPTION
Two commits, mostly minor improvements, feel free to pick or drop either or close the whole MR.

- cli: construct reduce duplication a bit
- cli: use FromStr and fallback to parse MachineFormat and IRFormat
